### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/extractors/cache.py
+++ b/extractors/cache.py
@@ -6,7 +6,7 @@ try:
 except ImportError:
     import pickle
 
-# consider https://dogpilecache.readthedocs.org/en/latest
+# consider https://dogpilecache.readthedocs.io/en/latest
 # also: locking :)
 log = logging.getLogger(__name__)
 CACHE_DIR = os.environ.get('EXTRACTORS_CACHE_DIR')

--- a/extractors/tesseract.py
+++ b/extractors/tesseract.py
@@ -12,8 +12,8 @@ from tesserwrap import Tesseract, PageSegMode
 from extractors.constants import _get_languages
 from extractors.cache import set_cache, get_cache
 
-# https://tesserwrap.readthedocs.org/en/latest/#
-# https://pillow.readthedocs.org/en/3.0.x/reference/Image.html
+# https://tesserwrap.readthedocs.io/en/latest/#
+# https://pillow.readthedocs.io/en/3.0.x/reference/Image.html
 log = logging.getLogger(__name__)
 TESSDATA_PREFIX = os.environ.get('TESSDATA_PREFIX')
 PDFTOPPM_BIN = os.environ.get('PDFTOPPM_BIN', 'pdftoppm')


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.
